### PR TITLE
Enforce constraint on length of name_prefix

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,13 @@ variable "owner" {
 }
 
 variable "name_prefix" {
+  type = string
   description = "prefix used in resource names"
+  
+  validation {
+    condition     = length(var.name_prefix) <= 10
+    error_message = "The name_prefix value must be 10 characters or less to comply with AWS name length rules."
+  }
 }
 
 variable "key_name" {


### PR DESCRIPTION
Once this `name_prefix` is combined with other values in the module, it's easy to overrun the number of characters allowed by AWS. If this value is 10 characters or less, it will not overrun the length constraint.