### PR TITLE
Modify variables sg rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.1 (August 19, 2020)
+
+IMPROVEMENTS:
+
+* security:
+  - added security group rule to expose API/UI to allowed CIDR blocks
+  - exposed `elb_internal` variable to user
+* documentation: updated README
+
 ## 0.2.0 (August 13, 2020)
 
 IMPROVEMENTS:

--- a/README.md
+++ b/README.md
@@ -50,9 +50,16 @@ This code is released under the MPL 2.0 License. Please see
 [LICENSE](https://github.com/hashicorp/terraform-aws-vault-oss/blob/master/LICENSE)
 for more details.
 
-## Note
+## Notes
 
-This module creates AWS Lambda functions and places them inside the VPC. Due to
+- This modules assumes you are using a default VPC and provides defaults for the
+  variables listed below. Please change the values of these variables based on
+  your VPC CIDR block. If you are not using a default VPC.
+    - `nat_gateway_subnet_cidr`
+    - `lambda_primary_subnet_cidr`
+    - `lambda_secondary_subnet_cidr`
+
+- This module creates AWS Lambda functions and places them inside the VPC. Due to
 this and some VPC networking changes AWS has recently deployed, it can take up
 45 minutes to successfully delete this environment. See [the following
 documentation](https://www.terraform.io/docs/providers/aws/r/lambda_function.html)

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ module "vault_cluster" {
   vault_version                = var.vault_version
   owner                        = var.owner
   name_prefix                  = var.name_prefix
+  elb_internal                 = var.elb_internal
   key_name                     = var.key_name
   instance_type                = var.instance_type
   vault_nodes                  = var.vault_nodes

--- a/modules/vault_cluster/security_groups.tf
+++ b/modules/vault_cluster/security_groups.tf
@@ -42,6 +42,16 @@ resource "aws_security_group_rule" "vault_elb_access" {
   cidr_blocks       = [data.aws_vpc.vault_vpc.cidr_block]
 }
 
+# Expose Vault API to allowed inbound CIDR
+resource "aws_security_group_rule" "vault_ui_ingress" {
+  security_group_id = aws_security_group.vault.id
+  type              = "ingress"
+  from_port         = 8200
+  to_port           = 8200
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_inbound_cidrs
+}
+
 # this rule is needed for the health checking done in the ASG
 # at startup as well as peer auto-removal
 resource "aws_security_group_rule" "vault_internal_access" {

--- a/modules/vault_cluster/variables.tf
+++ b/modules/vault_cluster/variables.tf
@@ -13,7 +13,6 @@ variable "vault_elb_health_check" {
 
 variable "elb_internal" {
   type        = bool
-  default     = true
   description = "make LB internal or external"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,11 @@ variable "name_prefix" {
   description = "prefix used in resource names"
 }
 
+variable "elb_internal" {
+  description = "make LB internal or external"
+  default     = true
+}
+
 variable "key_name" {
   description = "SSH key name for Vault instances"
 }


### PR DESCRIPTION
Expose `elb_internal` variable to end user and add security group rule to allow API/UI access from approved inbound CIDR block.