### PR TITLE
Update aws provider version constraints

### DIFF
--- a/examples/aws-secrets-manager-acm/version.tf
+++ b/examples/aws-secrets-manager-acm/version.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
 
   required_providers {
-    aws = ">= 3.0.0, < 4.0.0"
+    aws = ">= 3.0.0, <= 4.8.0"
     tls = ">= 3.0.0, < 4.0.0"
   }
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -2,7 +2,11 @@ data "aws_vpc" "selected" {
   id = var.vpc_id
 }
 
-data "aws_subnet_ids" "vault" {
-  vpc_id = data.aws_vpc.selected.id
-  tags   = var.private_subnet_tags
+data "aws_subnets" "vault" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+
+  tags = var.private_subnet_tags
 }

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -1,5 +1,5 @@
 output "vault_subnet_ids" {
-  value = data.aws_subnet_ids.vault.ids
+  value = data.aws_subnets.vault.ids
 }
 
 output "vpc_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.15"
 
   required_providers {
-    aws = ">= 3.0.0, < 4.0.0"
+    aws = ">= 3.0.0, <= 4.8.0"
   }
 }


### PR DESCRIPTION
After the [release '4.0.0'](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#400-february-10-2022) of the AWS provider some declarations are being deprecated:

- the data source 'aws_subnet_ids' in favor of using 'aws_subnets'
- the argument `tags` from the resource `aws_autoscaling_group` in favor of only using `tag`