### PR TITLE
Changed CA common name to avoid issue of the server certificate being invalid

### DIFF
--- a/examples/prereqs_quickstart/secrets/tls.tf
+++ b/examples/prereqs_quickstart/secrets/tls.tf
@@ -16,7 +16,7 @@ resource "tls_self_signed_cert" "ca" {
   private_key_pem = tls_private_key.ca.private_key_pem
 
   subject {
-    common_name = "vault.server.com"
+    common_name = "ca.vault.server.com"
   }
 
   validity_period_hours = 720 # 30 days


### PR DESCRIPTION
As said in the title, in its current version, the example for generating a SSL certificates is not working:

```bash
; openssl verify -verbose -CAfile cchain.pem cbody.crt
CN = vault.server.com
error 18 at 0 depth lookup: self signed certificate
error cbody.crt: verification failed
```

With the modification however, the certificate become valid.

See [this StackOverflow question](https://stackoverflow.com/questions/19726138/openssl-error-18-at-0-depth-lookupself-signed-certificate) for more details.

